### PR TITLE
fix: add /github/home/.local/bin to PATH

### DIFF
--- a/python-tools/Dockerfile
+++ b/python-tools/Dockerfile
@@ -7,7 +7,7 @@ LABEL "version"="1.0.0"
 LABEL "com.github.actions.name"="GitHub Action for Python"
 LABEL "com.github.actions.description"="Run actions requring Python. Some usual tools are preinstalled, such as black, mypy, bandit, or pylint."
 LABEL "com.github.actions.icon"="check-circle"
-LABEL "com.github.actions.color"="red"
+LABEL "com.github.actions.color"="purple"
 
 RUN pip install --upgrade pip \
   && pip install \

--- a/python-tools/README.md
+++ b/python-tools/README.md
@@ -33,6 +33,9 @@ It automatically prefixes the command with a `poetry run` or a `pipenv run` if a
 dependency file is detected (`pyproject.toml` or `Pipfile`) and the first word
 isn't `poetry` or `pipenv` itself.
 
+:warning: Note: use `pip install --user` to install packages in user repository,
+which gets passed down to subsequent actions.
+
 ## Credits
 
 Credits to [abatilo/actions-poetry](https://github.com/abatilo/actions-poetry),

--- a/python-tools/entrypoint.sh
+++ b/python-tools/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+export PATH="/github/home/.local/bin:$PATH"
+
 first_command=${1:-}
 
 if [[ -z "$first_command" ]]; then


### PR DESCRIPTION
Pip installs packages to ~/.local/bin, which is not in PATH by default and results in commands added by dependencies not being found.